### PR TITLE
 || 0 statement in post#timesort_comments not needed

### DIFF
--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -25,7 +25,7 @@ class Post < ApplicationRecord
   end
 
   def timesort_comments
-    self.comments.sort_by { |comment| comment.created_at || 0}.reverse
+    self.comments.sort_by { |comment| comment.created_at }.reverse
   end
 
   def find_like(user)


### PR DESCRIPTION
minor tidy up - since we are no longer generating blank comments, the || 0 bit in the sorting method 'timesort_comments' in 'post' isn't neccessary.